### PR TITLE
Add Linux support

### DIFF
--- a/fetch-usage.sh
+++ b/fetch-usage.sh
@@ -13,14 +13,24 @@ TOKEN_TTL=900  # 15 minutes
 # --- get token (with 15-min cache to avoid repeated credential reads) ---
 token=""
 if [ -f "$TOKEN_CACHE" ]; then
-  cache_age=$(( $(date -u +%s) - $(stat -f %m "$TOKEN_CACHE" 2>/dev/null || echo 0) ))
+  if stat -f %m "$TOKEN_CACHE" > /dev/null 2>&1; then
+    mtime=$(stat -f %m "$TOKEN_CACHE" 2>/dev/null)   # macOS
+  else
+    mtime=$(stat -c %Y "$TOKEN_CACHE" 2>/dev/null)   # Linux
+  fi
+  cache_age=$(( $(date -u +%s) - ${mtime:-0} ))
   if [ "$cache_age" -lt "$TOKEN_TTL" ]; then
     token=$(cat "$TOKEN_CACHE" 2>/dev/null)
   fi
 fi
 
 if [ -z "$token" ]; then
-  creds_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+  # macOS: read from Keychain; Linux: read from credentials file
+  if command -v security > /dev/null 2>&1; then
+    creds_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+  else
+    creds_json=$(cat "$HOME/.claude/.credentials.json" 2>/dev/null)
+  fi
   if [ -z "$creds_json" ]; then
     exit 0
   fi

--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -33,7 +33,11 @@ fi
 # --- compute_delta: given a raw ISO timestamp, returns human-readable time until reset ---
 compute_delta() {
   clean=$(echo "$1" | sed 's/\.[0-9]*//' | sed 's/[+-][0-9][0-9]:[0-9][0-9]$//' | sed 's/Z$//')
+  # macOS (BSD date): date -j -f; Linux (GNU date): date -d
   reset_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean" "+%s" 2>/dev/null)
+  if [ -z "$reset_epoch" ]; then
+    reset_epoch=$(date -u -d "${clean}Z" "+%s" 2>/dev/null)
+  fi
   if [ -z "$reset_epoch" ]; then return; fi
   now_epoch=$(date -u "+%s")
   diff=$(( reset_epoch - now_epoch ))


### PR DESCRIPTION
## Summary

- **`fetch-usage.sh`**: detect `stat` variant (BSD `-f %m` vs GNU `-c %Y`) for token cache age; read credentials from `~/.claude/.credentials.json` on Linux instead of macOS Keychain (`security` CLI)
- **`statusline-command.sh`**: fall back to GNU `date -d` for ISO timestamp parsing when BSD `date -j` is unavailable

## Test plan

- [ ] Verify token cache age calculation works on Linux (`stat -c %Y`)
- [ ] Verify credentials are read from `~/.claude/.credentials.json` on Linux
- [ ] Verify reset time countdown displays correctly on Linux (`date -d`)
- [ ] Verify existing macOS behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)