### PR TITLE
Refresh expired OAuth tokens instead of silently failing

### DIFF
--- a/fetch-usage.sh
+++ b/fetch-usage.sh
@@ -2,15 +2,54 @@
 # Fetches Claude API usage stats and writes them to /tmp/.claude_usage_cache.
 # Line 1: five_hour.utilization (integer %)
 # Line 2: seven_day.utilization (integer %)
-# Line 3: five_hour.resets_at (raw ISO string, e.g. 2026-02-26T12:59:59.997656+00:00)
+# Line 3: five_hour.resets_at (raw ISO string)
 # Line 4: seven_day.resets_at (raw ISO string)
-# All output is suppressed; meant to be run in background.
 
 CACHE_FILE="/tmp/.claude_usage_cache"
 TOKEN_CACHE="/tmp/.claude_token_cache"
-TOKEN_TTL=900  # 15 minutes
+TOKEN_TTL=900
 
-# --- get token (with 15-min cache to avoid repeated credential reads) ---
+CLIENT_ID="9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+OAUTH_ENDPOINT="https://api.anthropic.com/v1/oauth/token"
+USAGE_ENDPOINT="https://api.anthropic.com/oauth/usage"
+
+get_creds_json() {
+  security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null
+}
+
+refresh_access_token() {
+  _creds=$1
+  _refresh=$(printf '%s' "$_creds" | jq -r '.claudeAiOauth.refreshToken // empty' 2>/dev/null)
+  [ -z "$_refresh" ] && return 1
+
+  _resp=$(curl -s -m 5 \
+    -X POST "$OAUTH_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -d "{\"grant_type\":\"refresh_token\",\"refresh_token\":\"$_refresh\",\"client_id\":\"$CLIENT_ID\"}" 2>/dev/null)
+
+  _new_access=$(printf '%s' "$_resp" | jq -r '.access_token // empty' 2>/dev/null)
+  _new_refresh=$(printf '%s' "$_resp" | jq -r '.refresh_token // empty' 2>/dev/null)
+  _expires_in=$(printf '%s' "$_resp" | jq -r '.expires_in // empty' 2>/dev/null)
+  [ -z "$_new_access" ] && return 1
+
+  _expires_at=$(( $(date -u +%s) * 1000 + _expires_in * 1000 ))
+
+  _updated=$(printf '%s' "$_creds" | jq \
+    --arg at "$_new_access" \
+    --arg rt "${_new_refresh:-$_refresh}" \
+    --argjson ea "$_expires_at" \
+    '.claudeAiOauth.accessToken = $at | .claudeAiOauth.refreshToken = $rt | .claudeAiOauth.expiresAt = $ea' 2>/dev/null)
+
+  if [ -n "$_updated" ]; then
+    security delete-generic-password -s "Claude Code-credentials" >/dev/null 2>&1
+    security add-generic-password -s "Claude Code-credentials" -a "" -w "$_updated" 2>/dev/null
+  fi
+
+  printf '%s' "$_new_access"
+}
+
+# --- get token (with cache) ---
 token=""
 if [ -f "$TOKEN_CACHE" ]; then
   cache_age=$(( $(date -u +%s) - $(stat -f %m "$TOKEN_CACHE" 2>/dev/null || echo 0) ))
@@ -20,27 +59,48 @@ if [ -f "$TOKEN_CACHE" ]; then
 fi
 
 if [ -z "$token" ]; then
-  creds_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
-  if [ -z "$creds_json" ]; then
-    exit 0
-  fi
-  token=$(printf '%s' "$creds_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
-  if [ -z "$token" ]; then
-    exit 0
+  creds_json=$(get_creds_json)
+  [ -z "$creds_json" ] && exit 0
+
+  expires_at=$(printf '%s' "$creds_json" | jq -r '.claudeAiOauth.expiresAt // 0' 2>/dev/null)
+  now_ms=$(( $(date -u +%s) * 1000 ))
+
+  if [ "$now_ms" -ge "$expires_at" ]; then
+    token=$(refresh_access_token "$creds_json")
+    [ -z "$token" ] && exit 0
+  else
+    token=$(printf '%s' "$creds_json" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+    [ -z "$token" ] && exit 0
   fi
   printf '%s' "$token" > "$TOKEN_CACHE"
 fi
 
+# --- fetch usage ---
 usage_json=$(curl -s -m 3 \
   -H "accept: application/json" \
   -H "anthropic-beta: oauth-2025-04-20" \
   -H "authorization: Bearer $token" \
   -H "user-agent: claude-code/2.1.11" \
-  "https://api.anthropic.com/oauth/usage" 2>/dev/null)
+  "$USAGE_ENDPOINT" 2>/dev/null)
 
-if [ -z "$usage_json" ]; then
-  exit 0
+# If 401, token might have expired mid-cache; try refresh once
+if printf '%s' "$usage_json" | grep -q '"authentication_error"' 2>/dev/null; then
+  rm -f "$TOKEN_CACHE"
+  creds_json=$(get_creds_json)
+  [ -z "$creds_json" ] && exit 0
+  token=$(refresh_access_token "$creds_json")
+  [ -z "$token" ] && exit 0
+  printf '%s' "$token" > "$TOKEN_CACHE"
+
+  usage_json=$(curl -s -m 3 \
+    -H "accept: application/json" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "authorization: Bearer $token" \
+    -H "user-agent: claude-code/2.1.11" \
+    "$USAGE_ENDPOINT" 2>/dev/null)
 fi
+
+[ -z "$usage_json" ] && exit 0
 
 five_h_raw=$(printf '%s' "$usage_json" | jq -r '.five_hour.utilization // empty' 2>/dev/null)
 seven_d_raw=$(printf '%s' "$usage_json" | jq -r '.seven_day.utilization // empty' 2>/dev/null)

--- a/fetch-usage.sh
+++ b/fetch-usage.sh
@@ -14,7 +14,14 @@ OAUTH_ENDPOINT="https://api.anthropic.com/v1/oauth/token"
 USAGE_ENDPOINT="https://api.anthropic.com/oauth/usage"
 
 get_creds_json() {
-  security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null
+  _raw=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+  [ -z "$_raw" ] && return 1
+  _decoded=$(printf '%s' "$_raw" | xxd -r -p 2>/dev/null)
+  if printf '%s' "$_decoded" | jq empty 2>/dev/null; then
+    printf '%s' "$_decoded"
+  else
+    printf '%s' "$_raw"
+  fi
 }
 
 refresh_access_token() {
@@ -42,8 +49,9 @@ refresh_access_token() {
     '.claudeAiOauth.accessToken = $at | .claudeAiOauth.refreshToken = $rt | .claudeAiOauth.expiresAt = $ea' 2>/dev/null)
 
   if [ -n "$_updated" ]; then
+    _hex=$(printf '%s' "$_updated" | xxd -p | tr -d '\n')
     security delete-generic-password -s "Claude Code-credentials" >/dev/null 2>&1
-    security add-generic-password -s "Claude Code-credentials" -a "" -w "$_updated" 2>/dev/null
+    security add-generic-password -s "Claude Code-credentials" -a "" -w "$_hex" 2>/dev/null
   fi
 
   printf '%s' "$_new_access"


### PR DESCRIPTION
## Problem

`fetch-usage.sh` reads the OAuth access token from the macOS Keychain but never refreshes it when it expires. Claude Code's OAuth tokens expire after ~8 hours. Once stale, the usage API returns 401 and the script silently exits — the status line just shows nothing with no indication of what's wrong.

## Fix

Adds automatic token refresh via the `/v1/oauth/token` endpoint:

- Checks `expiresAt` from the Keychain before calling the usage API
- When expired, refreshes using the stored `refreshToken` and Claude Code's OAuth `client_id`
- Retries once on 401 in case the token expires mid-cache window
- Writes refreshed tokens (including the rotated refresh token) back to the Keychain so they stay in sync with Claude Code

## Notes

- Only affects macOS (same as the existing Keychain-based token retrieval)
- No new dependencies — uses the same `curl`, `jq`, and `security` commands already required
- Fails gracefully: if the refresh fails, the script exits silently like before